### PR TITLE
Allow using AddMissingSchemas in net8 too

### DIFF
--- a/src/MinimalHelpers.OpenApi/Filters/MissingSchemasOperationFilter.cs
+++ b/src/MinimalHelpers.OpenApi/Filters/MissingSchemasOperationFilter.cs
@@ -5,7 +5,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MinimalHelpers.OpenApi.Filters;
 
-#if NET7_0
+#if NET7_0_OR_GREATER
 internal class MissingSchemasOperationFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)

--- a/src/MinimalHelpers.OpenApi/SwaggerExtensions.cs
+++ b/src/MinimalHelpers.OpenApi/SwaggerExtensions.cs
@@ -10,7 +10,7 @@ namespace MinimalHelpers.OpenApi;
 /// </summary>
 public static class SwaggerExtensions
 {
-#if NET7_0
+#if NET7_0_OR_GREATER
     /// <summary>
     /// Adds an <see cref="IOperationFilter"/> that extends <see langword="swagger.json"/> generation with missing schemas for common types (<see langword="Guid"/>, <see langword="DateTime"/>, <see langword="DateOnly"/> and <see langword="TimeOnly"/>) when using the <see langword="WithOpenApi"/> extension method on endpoints.
     /// </summary>


### PR DESCRIPTION
Updated the directive to include .Net version greater than 7 for the MissingSchemasOperationFilter and the extension method to add this OperationFilter