### PR TITLE
Update Swashbuckle.AspNetCore to version 6.8.0

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -38,6 +38,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.3" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the `MinimalSample.csproj` file to change the version of the `Swashbuckle.AspNetCore` package from `6.7.3` to `6.8.0`. Updated the `MinimalHelpers.OpenApi.csproj` file to change the version of the `Swashbuckle.AspNetCore.SwaggerGen` package from `6.7.3` to `6.8.0`.

These updates likely include bug fixes, new features, or other improvements provided in the newer version of the packages.