### PR TITLE
Update Swashbuckle packages and improve parameter matching

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -38,6 +38,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.8.1" />
     </ItemGroup>
 </Project>

--- a/src/MinimalHelpers.OpenApi/SwaggerExtensions.cs
+++ b/src/MinimalHelpers.OpenApi/SwaggerExtensions.cs
@@ -30,7 +30,7 @@ public static class SwaggerExtensions
     /// <returns>The <see cref="OpenApiParameter"/> object with the specified name.</returns>
     /// <exception cref="InvalidOperationException">The parameter with the specified name was not found.</exception>    
     public static OpenApiParameter GetByName(this IList<OpenApiParameter> parameters, string name)
-        => parameters.Single(p => p.Name == name);
+        => parameters.Single(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Gets by name the <see cref="OpenApiParameter"/> that is available in the <see cref="OpenApiOperation"/> parameters list.


### PR DESCRIPTION
Updated `MinimalSample.csproj` to change `Swashbuckle.AspNetCore` version from `6.8.0` to `6.8.1`. Similarly, updated `MinimalHelpers.OpenApi.csproj` to change `Swashbuckle.AspNetCore.SwaggerGen` version from `6.8.0` to `6.8.1`. Modified `GetByName` extension method in `SwaggerExtensions.cs` to use case-insensitive comparison for parameter names with `StringComparison.OrdinalIgnoreCase`.