### PR TITLE
Update comments and add project reference

### DIFF
--- a/samples/MinimalSample/Handlers/ProductsHandler.cs
+++ b/samples/MinimalSample/Handlers/ProductsHandler.cs
@@ -11,11 +11,11 @@ public class ProductsHandler : IEndpointRouteHandlerBuilder
         endpoints.MapGet("/api/products/{id:guid}", Get);
 
         endpoints.MapPost("/api/products", Insert)
-            // MinimalHelpers.FluentValidation package performs validation with Data Annotations.
+            // MinimalHelpers.FluentValidation package performs validation using FluentValidation.
             .WithValidation<Product>();
 
         endpoints.MapPut("/api/products/{id:guid}", Update)
-            // MinimalHelpers.FluentValidation package performs validation with Data Annotations.
+            // MinimalHelpers.FluentValidation package performs validation using FluentValidation.
             .WithValidation<Product>();
 
         endpoints.MapDelete("/api/products/{id:guid}", Delete);

--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -16,6 +16,7 @@
 		<ProjectReference Include="..\..\src\MinimalHelpers.FluentValidation\MinimalHelpers.FluentValidation.csproj" />
 		<ProjectReference Include="..\..\src\MinimalHelpers.OpenApi\MinimalHelpers.OpenApi.csproj" />
 		<ProjectReference Include="..\..\src\MinimalHelpers.Routing.Analyzers\MinimalHelpers.Routing.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\..\src\MinimalHelpers.Validation.Abstractions\MinimalHelpers.Validation.Abstractions.csproj" />
 		<ProjectReference Include="..\..\src\MinimalHelpers.Validation\MinimalHelpers.Validation.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated `ProductsHandler.cs` to correct comments about `MinimalHelpers.FluentValidation` package, clarifying it uses FluentValidation for validation instead of Data Annotations. Added a new project reference in `MinimalSample.csproj` to `..\..\src\MinimalHelpers.Validation.Abstractions\MinimalHelpers.Validation.Abstractions.csproj`.