### PR TITLE
Rename EndpointHandlerGenerator to EndpointRouteHandlerGenerator

### DIFF
--- a/src/MinimalHelpers.Routing.Analyzers/EndpointRouteHandlerGenerator.cs
+++ b/src/MinimalHelpers.Routing.Analyzers/EndpointRouteHandlerGenerator.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace MinimalHelpers.Routing.Analyzers;
 
 [Generator]
-public class EndpointHandlerGenerator : IIncrementalGenerator
+public class EndpointRouteHandlerGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {


### PR DESCRIPTION
Renamed the file `EndpointHandlerGenerator.cs` to `EndpointRouteHandlerGenerator.cs`. Updated the namespace and class name accordingly.