### PR TITLE
Add ProducesDefaultProblem method to RouteHandlerBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,26 @@ endpoints.MapPost("login", LoginAsync)
     });
  ```
 
+ ***Extension methods for RouteHandlerBuilder***
+
+ Often we have endpoints with multiple 4xx return values, each of which produces a `ProblemDetails` response:
+
+ ```csharp
+ endpoints.MapGet("/api/people/{id:guid}", Get)
+    .ProducesProblem(StatusCodes.Status400BadRequest)
+    .ProducesProblem(StatusCodes.Status401Unauthorized)
+    .ProducesProblem(StatusCodes.Status403Forbidden)
+    .ProducesProblem(StatusCodes.Status404NotFound);
+ ```
+
+ To avoid multiple calls to `ProducesProblem`, we can use the `ProducesDefaultProblem` extension method provided by the library:
+
+ ```csharp
+endpoints.MapGet("/api/people/{id:guid}", Get)
+    .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized,
+        StatusCodes.Status403Forbidden, StatusCodes.Status404NotFound);
+ ```
+
 ## MinimalHelpers.Validation
 
 [![Nuget](https://img.shields.io/nuget/v/MinimalHelpers.Validation)](https://www.nuget.org/packages/MinimalHelpers.Validation)

--- a/samples/MinimalSample/Endpoints/PeopleEndpoints.cs
+++ b/samples/MinimalSample/Endpoints/PeopleEndpoints.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using MinimalHelpers.OpenApi;
 using MinimalHelpers.Validation;
 
 namespace MinimalSample.Endpoints;
@@ -9,7 +10,12 @@ public class PeopleEndpoints : IEndpointRouteHandlerBuilder
     {
         endpoints.MapGet("/api/people", GetList);
 
-        endpoints.MapGet("/api/people/{id:guid}", Get);
+        endpoints.MapGet("/api/people/{id:guid}", Get)
+            //.ProducesProblem(StatusCodes.Status400BadRequest)
+            //.ProducesProblem(StatusCodes.Status401Unauthorized)
+            //.ProducesProblem(StatusCodes.Status403Forbidden)
+            //.ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status403Forbidden, StatusCodes.Status404NotFound);
 
         endpoints.MapPost("/api/people", Insert)
             // MinimalHelpers.Validation package performs validation with Data Annotations.

--- a/src/MinimalHelpers.FluentValidation/RouteHandlerBuilderExtensions.cs
+++ b/src/MinimalHelpers.FluentValidation/RouteHandlerBuilderExtensions.cs
@@ -11,7 +11,7 @@ public static class RouteHandlerBuilderExtensions
 {
     /// <summary>
     /// Registers a <seealso cref="ValidatorFilter{T}"/> of type <typeparamref name="T"/> onto the route handler to validate the <typeparamref name="T"/> object.
-    /// </summary> 
+    /// </summary>
     /// <typeparam name="T">The type of the object to validate.</typeparam>
     /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to add validation filter to.</param>
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>

--- a/src/MinimalHelpers.FluentValidation/RouteHandlerBuilderExtensions.cs
+++ b/src/MinimalHelpers.FluentValidation/RouteHandlerBuilderExtensions.cs
@@ -10,12 +10,13 @@ namespace MinimalHelpers.FluentValidation;
 public static class RouteHandlerBuilderExtensions
 {
     /// <summary>
-    /// Adds to the <see cref="RouteHandlerBuilder"/> a filter that validates the <typeparamref name="T"/> object.
-    /// </summary>
+    /// Registers a <seealso cref="ValidatorFilter{T}"/> of type <typeparamref name="T"/> onto the route handler to validate the <typeparamref name="T"/> object.
+    /// </summary> 
     /// <typeparam name="T">The type of the object to validate.</typeparam>
     /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to add validation filter to.</param>
-    /// <returns>The <see cref="RouteHandlerBuilder"/> with the added validation filter.</returns>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
     /// <remarks>The validation is performed using <a href="https://fluentvalidation.net">FluentValidation</a>.</remarks>
+    /// <seealso cref="ValidatorFilter{T}"/>    
     public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder) where T : class
     {
         builder.AddEndpointFilter<ValidatorFilter<T>>()

--- a/src/MinimalHelpers.OpenApi/RouteHandlerBuilderExtensions.cs
+++ b/src/MinimalHelpers.OpenApi/RouteHandlerBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MinimalHelpers.OpenApi;
+
+/// <summary>
+/// Extension methods for <see cref="RouteHandlerBuilder"/>.
+/// </summary>
+/// <seealso cref="RouteHandlerBuilder"/>
+public static class RouteHandlerBuilderExtensions
+{
+    /// <summary>
+    /// Adds to <see cref="RouteHandlerBuilder"/> the specified list of status codes as <see cref="ProblemDetails"/> responses.
+    /// </summary>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder"/>.</param>
+    /// <param name="statusCodes">The list of status codes to be added as <see cref="ProblemDetails"/> responses.</param>
+    /// <returns>The <see cref="RouteHandlerBuilder"/> with the new status codes responses.</returns>
+    public static RouteHandlerBuilder ProducesDefaultProblem(this RouteHandlerBuilder builder, params int[] statusCodes)
+    {
+        foreach (var statusCode in statusCodes)
+        {
+            builder.ProducesProblem(statusCode);
+        }
+
+        return builder;
+    }
+}

--- a/src/MinimalHelpers.Validation/RouteHandlerBuilderExtensions.cs
+++ b/src/MinimalHelpers.Validation/RouteHandlerBuilderExtensions.cs
@@ -11,7 +11,7 @@ public static class RouteHandlerBuilderExtensions
 {
     /// <summary>
     /// Registers a <seealso cref="ValidatorFilter{T}"/> of type <typeparamref name="T"/> onto the route handler to validate the <typeparamref name="T"/> object.
-    /// </summary> 
+    /// </summary>
     /// <typeparam name="T">The type of the object to validate.</typeparam>
     /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to add validation filter to.</param>
     /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>

--- a/src/MinimalHelpers.Validation/RouteHandlerBuilderExtensions.cs
+++ b/src/MinimalHelpers.Validation/RouteHandlerBuilderExtensions.cs
@@ -10,12 +10,13 @@ namespace MinimalHelpers.Validation;
 public static class RouteHandlerBuilderExtensions
 {
     /// <summary>
-    /// Adds to the <see cref="RouteHandlerBuilder"/> a filter that validates the <typeparamref name="T"/> object.
-    /// </summary>
+    /// Registers a <seealso cref="ValidatorFilter{T}"/> of type <typeparamref name="T"/> onto the route handler to validate the <typeparamref name="T"/> object.
+    /// </summary> 
     /// <typeparam name="T">The type of the object to validate.</typeparam>
     /// <param name="builder">The <see cref="RouteHandlerBuilder"/> to add validation filter to.</param>
-    /// <returns>The <see cref="RouteHandlerBuilder"/> with the added validation filter.</returns>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customize the route handler.</returns>
     /// <remarks>The validation is performed with Data annotations, using <a href="https://github.com/DamianEdwards/MiniValidation">MiniValidation</a>.</remarks>
+    /// <seealso cref="ValidatorFilter{T}"/>
     public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder) where T : class
     {
         builder.AddEndpointFilter<ValidatorFilter<T>>()


### PR DESCRIPTION
Introduce a new extension method `ProducesDefaultProblem` for the `RouteHandlerBuilder` class to simplify defining common error responses.

Enhance `README.md` with documentation and examples for the new method.

Closes #64 