### PR TITLE
Upgrade various packages and fix build output syntax

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.1.0" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.15" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -30,11 +30,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.12" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalHelpers.Validation/MinimalHelpers.Validation.csproj
+++ b/src/MinimalHelpers.Validation/MinimalHelpers.Validation.csproj
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MiniValidation" Version="0.9.1" />
+      <PackageReference Include="MiniValidation" Version="0.9.2" />
     </ItemGroup>
 
     <ItemGroup>
@@ -54,7 +54,7 @@
 
     <Target Name="IncludeProjectReferenceDlls" DependsOnTargets="BuildOnlySettings;ResolveReferences">
         <ItemGroup>
-            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>
+            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" />
         </ItemGroup>
     </Target>
 </Project>


### PR DESCRIPTION
Upgraded multiple packages across several project files:
- `MinimalSample.csproj`: Upgraded `Microsoft.AspNetCore.OpenApi`, `Swashbuckle.AspNetCore.SwaggerUI`, and `TinyHelpers.AspNetCore`.
- `Directory.Build.props`: Upgraded `Nerdbank.GitVersioning`.
- `MinimalHelpers.OpenApi.csproj`: Upgraded `Microsoft.AspNetCore.OpenApi` for `net8.0` and `net9.0`.
- `MinimalHelpers.Validation.csproj`: Upgraded `MiniValidation`.

Also corrected the syntax for the `BuildOutputInPackage` item group in `MinimalHelpers.Validation.csproj`.