### PR TITLE
Update package versions in MinimalSample.csproj

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -9,8 +9,8 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.18" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.0" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.19" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Upgraded `Swashbuckle.AspNetCore.SwaggerUI` to version `7.3.0` and `TinyHelpers.AspNetCore` to version
`4.0.19`. Removed previous versions from the project file.