### PR TITLE
Update SwaggerUI package version

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.0.0" />
 		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.21" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated the `Swashbuckle.AspNetCore.SwaggerUI` package from version `7.3.2` to `8.0.0` in the `MinimalSample.csproj` file.