### PR TITLE
Update package references in project files

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.0.0" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.21" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.23" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -30,11 +30,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated package versions in `MinimalSample.csproj` for `Microsoft.AspNetCore.OpenApi` (9.0.4),
`Swashbuckle.AspNetCore.SwaggerUI` (8.1.0), and
`TinyHelpers.AspNetCore` (4.0.23).

Modified `MinimalHelpers.OpenApi.csproj` to upgrade `Microsoft.AspNetCore.OpenApi` to version 8.0.15 for `net8.0` and 9.0.4 for `net9.0`.