### PR TITLE
Update package versions and OpenAPI configuration

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -7,10 +7,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.23" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.25" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/MinimalSample/Program.cs
+++ b/samples/MinimalSample/Program.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi(options =>
 {
-    options.AddDefaultResponse();
+    options.AddDefaultProblemDetailsResponse();
 });
 
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();

--- a/src/MinimalHelpers.FluentValidation/MinimalHelpers.FluentValidation.csproj
+++ b/src/MinimalHelpers.FluentValidation/MinimalHelpers.FluentValidation.csproj
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.11.0" />
+      <PackageReference Include="FluentValidation" Version="12.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Upgraded `FluentValidation.DependencyInjectionExtensions` to version `12.0.0`.
- Updated `Swashbuckle.AspNetCore.SwaggerUI` to version `8.1.1`.
- Upgraded `TinyHelpers.AspNetCore` to version `4.0.25`.
- Changed OpenAPI configuration in `Program.cs` to use `AddDefaultProblemDetailsResponse()`.
- Aligned `FluentValidation` version in `MinimalHelpers.FluentValidation.csproj` to `12.0.0`.