### PR TITLE
Update package versions for OpenApi and TinyHelpers

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.25" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.26" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -30,11 +30,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Updated `Microsoft.AspNetCore.OpenApi` from `9.0.4` to `9.0.5` in `MinimalSample.csproj` and `MinimalHelpers.OpenApi.csproj`.
- Updated `TinyHelpers.AspNetCore` from `4.0.25` to `4.0.26` in `MinimalSample.csproj`.
- Updated `Microsoft.AspNetCore.OpenApi` for `net8.0` from `8.0.15` to `8.0.16` in `MinimalHelpers.OpenApi.csproj`.