### PR TITLE
Update Swashbuckle.AspNetCore.SwaggerUI package

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.2" />
 		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.26" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated the `Swashbuckle.AspNetCore.SwaggerUI` package version from `8.1.1` to `8.1.2` in the `MinimalSample.csproj` file. Other package references remain unchanged.