### PR TITLE
Update Microsoft.AspNetCore.OpenApi package versions

### DIFF
--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
 		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.26" />
 	</ItemGroup>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -30,11 +30,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated `Microsoft.AspNetCore.OpenApi` package versions in:
- `MinimalSample.csproj`: from `9.0.5` to `9.0.6`
- `MinimalHelpers.OpenApi.csproj` for `net8.0`: from `8.0.16` to `8.0.17`
- `MinimalHelpers.OpenApi.csproj` for `net9.0`: from `9.0.5` to `9.0.6`