### PR TITLE
Update .editorconfig and NuGet package versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -82,6 +82,7 @@ csharp_style_prefer_local_over_anonymous_function = true:silent
 csharp_style_prefer_extended_property_pattern = true:suggestion
 csharp_style_implicit_object_creation_when_type_is_apparent = true:silent
 csharp_style_prefer_tuple_swap = true:silent
+csharp_style_prefer_simple_property_accessors = true:suggestion
 
 # Field preferences
 dotnet_style_readonly_field = true:suggestion
@@ -300,3 +301,6 @@ dotnet_diagnostic.IDE0072.severity = none
 
 # IDE0305: Simplify collection initialization
 dotnet_diagnostic.IDE0305.severity = none
+
+# CA1873: Avoid potentially expensive logging
+dotnet_diagnostic.CA1873.severity = none

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@
 ### Implementation Guidelines
 
 - Write code that is secure by default. Avoid exposing potentially private or sensitive data.
-- Make code NativeAOT compatible when possible. This means avoiding dynamic code generation, reflection, and other features that are not compatible. with NativeAOT. If not possible, mark the code with an appropriate annotation or throw an exception.
+- Make code NativeAOT compatible when possible. This means avoiding dynamic code generation, reflection, and other features that are not compatible with NativeAOT. If not possible, mark the code with an appropriate annotation or throw an exception.
 
 ## Documentation
 

--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.6" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.8.118"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -30,11 +30,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.21" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated .editorconfig to include a new style preference for simple property accessors and adjusted diagnostic severities. Corrected text in `copilot-instructions.md` for clarity. Upgraded NuGet packages in `MinimalSample.csproj` and `MinimalHelpers.OpenApi.csproj` to newer versions, including `Microsoft.AspNetCore.OpenApi`, `Swashbuckle.AspNetCore.SwaggerUI`, and `TinyHelpers.AspNetCore`. Updated `Nerdbank.GitVersioning` in `Directory.Build.props`.