### PR TITLE
Migrate to .NET 10 and adopt FluentValidation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 ## General
 
 - Make only high confidence suggestions when reviewing code changes.
-- Always use the latest version C#, currently C# 13 features.
+- Always use the latest version C#, currently C# 14 features.
 - Write code that is clean, maintainable, and easy to understand.
 - Only add comments rarely to explain why a non-intuitive solution was used. The code should be self-explanatory otherwise.
 - Don't add the UTF-8 BOM to files unless they have non-ASCII characters.

--- a/README.md
+++ b/README.md
@@ -136,31 +136,6 @@ dotnet add package MinimalHelpers.OpenApi
 
 ### Usage
 
-***Extension methods for OpenApi***
-
-This library provides several extension methods that simplify the OpenAPI configuration in Minimal API projects. For example, you can customize the description of a response using its status code:
-
-```csharp
-endpoints.MapPost("login", LoginAsync)
-    .AllowAnonymous()
-    .WithValidation<LoginRequest>()
-    .Produces<LoginResponse>(StatusCodes.Status200OK)
-    .Produces<LoginResponse>(StatusCodes.Status206PartialContent)
-    .Produces(StatusCodes.Status403Forbidden)
-    .ProducesValidationProblem()
-    .WithOpenApi(operation =>
-    {
-        operation.Summary = "Performs the login of a user";
-
-        operation.Response(StatusCodes.Status200OK).Description = "Login successful";
-        operation.Response(StatusCodes.Status206PartialContent).Description = "The user is logged in, but the password has expired and must be changed";
-        operation.Response(StatusCodes.Status400BadRequest).Description = "Incorrect username and/or password";
-        operation.Response(StatusCodes.Status403Forbidden).Description = "The user was blocked due to too many failed logins";
-
-        return operation;
-    });
- ```
-
  ***Extension methods for RouteHandlerBuilder***
 
  Often, endpoints have multiple 4xx return values, each producing a `ProblemDetails` response:
@@ -180,93 +155,6 @@ endpoints.MapGet("/api/people/{id:guid}", Get)
     .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized,
         StatusCodes.Status403Forbidden, StatusCodes.Status404NotFound);
  ```
-
-## MinimalHelpers.Validation
-
-[![Nuget](https://img.shields.io/nuget/v/MinimalHelpers.Validation)](https://www.nuget.org/packages/MinimalHelpers.Validation)
-[![Nuget](https://img.shields.io/nuget/dt/MinimalHelpers.Validation)](https://www.nuget.org/packages/MinimalHelpers.Validation)
-
-A library that provides an endpoint filter for Minimal API projects to perform validation using Data Annotations and the <a href="https://github.com/DamianEdwards/MiniValidation">MiniValidation</a> library.
-
-### Installation
-
-The library is available on [NuGet](https://www.nuget.org/packages/MinimalHelpers.Validation). Search for *MinimalHelpers.Validation* in the **Package Manager GUI** or run the following command in the **.NET CLI**:
-
-```shell
-dotnet add package MinimalHelpers.Validation
-```
-
-### Usage
-
-Decorate a class with attributes to define the validation rules:
-
-```csharp
-using System.ComponentModel.DataAnnotations;
-
-public class Person
-{
-    [Required]
-    [MaxLength(20)]
-    public string? FirstName { get; set; }
-
-    [Required]
-    [MaxLength(20)]
-    public string? LastName { get; set; }
-
-    [MaxLength(50)]
-    public string? City { get; set; }
-}
-```
-
-Use the `WithValidation<TModel>()` extension method to enable the validation filter:
-
-```csharp
-using MinimalHelpers.Validation;
-
-app.MapPost("/api/people", (Person person) =>
-    {
-        // ...
-    })
-    .WithValidation<Person>();
-```
-
-If the validation fails, the response will be a `400 Bad Request` with a `ValidationProblemDetails` object containing the validation errors, for example:
-
-```json
-{
-  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
-  "title": "One or more validation errors occurred",
-  "status": 400,
-  "instance": "/api/people",
-  "traceId": "00-009c0162ba678cae2ee391815dbbb59d-0a3a5b0c16d053e6-00",
-  "errors": {
-    "FirstName": [
-      "The field FirstName must be a string or array type with a maximum length of '20'."
-    ],
-    "LastName": [
-      "The LastName field is required."
-    ]
-  }
-}
-```
-
-To customize validation, use the `ConfigureValidation` extension method:
-
-```csharp
-using MinimalHelpers.Validation;
-
-builder.Services.ConfigureValidation(options =>
-{
-    // If you want to get errors as a list instead of a dictionary.
-    options.ErrorResponseFormat = ErrorResponseFormat.List;
-
-    // The default is "One or more validation errors occurred"
-    options.ValidationErrorTitleMessageFactory =
-        (context, errors) => $"There was {errors.Values.Sum(v => v.Length)} error(s)";
-});
-```
-
-You can use the `ValidationErrorTitleMessageFactory`, for example, if you want to localize the `title` property of the response using a RESX file.
 
 ## MinimalHelpers.FluentValidation
 
@@ -290,13 +178,13 @@ Create a class that extends AbstractValidator<TModel> and define the validation 
 ```csharp
 using FluentValidation;
 
-public record class Product(string Name, string Description, double UnitPrice);
+public record class Product(string? Name, string? Description, double? UnitPrice);
 
 public class ProductValidator : AbstractValidator<Product>
 {
     public ProductValidator()
     {
-        RuleFor(p => p.Name).NotEmpty().MaximumLength(50).EmailAddress();
+        RuleFor(p => p.Name).NotEmpty().MaximumLength(50);
         RuleFor(p => p.Description).MaximumLength(500);
         RuleFor(p => p.UnitPrice).GreaterThan(0);
     }

--- a/samples/MinimalSample/Endpoints/PeopleEndpoints.cs
+++ b/samples/MinimalSample/Endpoints/PeopleEndpoints.cs
@@ -1,6 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using MinimalHelpers.FluentValidation;
 using MinimalHelpers.OpenApi;
-using MinimalHelpers.Validation;
 
 namespace MinimalSample.Endpoints;
 
@@ -18,11 +17,11 @@ public class PeopleEndpoints : IEndpointRouteHandlerBuilder
             .ProducesDefaultProblem(StatusCodes.Status400BadRequest, StatusCodes.Status401Unauthorized, StatusCodes.Status403Forbidden, StatusCodes.Status404NotFound);
 
         endpoints.MapPost("/api/people", Insert)
-            // MinimalHelpers.Validation package performs validation with Data Annotations.
+            // MinimalHelpers.FluentValidation package performs validation with Data Annotations.
             .WithValidation<Person>();
 
         endpoints.MapPut("/api/people/{id:guid}", Update)
-            // MinimalHelpers.Validation package performs validation with Data Annotations.
+            // MinimalHelpers.FluentValidation package performs validation with Data Annotations.
             .WithValidation<Person>();
 
         endpoints.MapDelete("/api/people/{id:guid}", Delete);
@@ -39,16 +38,4 @@ public class PeopleEndpoints : IEndpointRouteHandlerBuilder
     private static IResult Delete(Guid id) => TypedResults.NoContent();
 }
 
-public class Person
-{
-    [Required]
-    [MaxLength(20)]
-    public string? FirstName { get; set; }
-
-    [Required]
-    [MaxLength(20)]
-    public string? LastName { get; set; }
-
-    [MaxLength(50)]
-    public string? City { get; set; }
-}
+public record class Person(string? FirstName, string? LastName, string? City);

--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.8" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.1" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/MinimalSample/Validations/PersonValidator.cs
+++ b/samples/MinimalSample/Validations/PersonValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+using MinimalSample.Endpoints;
+
+namespace MinimalSample.Validations;
+
+public class PersonValidator : AbstractValidator<Person>
+{
+    public PersonValidator()
+    {
+        RuleFor(p => p.FirstName).NotEmpty().MaximumLength(20);
+        RuleFor(p => p.LastName).NotEmpty().MaximumLength(20);
+        RuleFor(p => p.City).MaximumLength(50);
+    }
+}

--- a/src/MinimalHelpers.FluentValidation/MinimalHelpers.FluentValidation.csproj
+++ b/src/MinimalHelpers.FluentValidation/MinimalHelpers.FluentValidation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -18,7 +18,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/marcominerva/MinimalHelpers.git</RepositoryUrl>
         <RepositoryBranch>master</RepositoryBranch>
-        <PackageReadmeFile>README.md</PackageReadmeFile>        
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -30,11 +30,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.21" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22" />
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MinimalHelpers.OpenApi/OpenApiExtensions.cs
+++ b/src/MinimalHelpers.OpenApi/OpenApiExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.OpenApi.Models;
+﻿#if NET8_0 || NET9_0
+
+using Microsoft.OpenApi.Models;
 
 namespace MinimalHelpers.OpenApi;
 
@@ -47,3 +49,53 @@ public static class OpenApiExtensions
     public static OpenApiResponse Response(this OpenApiOperation operation, int statusCode)
         => operation.Responses.GetByStatusCode(statusCode);
 }
+
+#elif NET10_0_OR_GREATER
+
+using Microsoft.OpenApi;
+
+namespace MinimalHelpers.OpenApi;
+
+/// <summary>
+/// Provides extension methods for OpenAPI objects.
+/// </summary>
+public static class OpenApiExtensions
+{
+    /// <summary>
+    /// Gets the <see cref="IOpenApiParameter"/> by name from the specified list of parameters.
+    /// </summary>
+    /// <param name="parameters">The list of <see cref="OpenApiParameter"/> objects.</param>
+    /// <param name="name">The name of the parameter to retrieve.</param>
+    /// <returns>The <see cref="IOpenApiParameter"/> object with the specified name.</returns>
+    public static IOpenApiParameter? GetByName(this IList<IOpenApiParameter> parameters, string name)
+        => parameters.SingleOrDefault(p => p.Name?.Equals(name, StringComparison.OrdinalIgnoreCase) == true);
+
+    /// <summary>
+    /// Gets by name the <see cref="IOpenApiParameter"/> that is available in the <see cref="OpenApiOperation"/> parameters list.
+    /// </summary>
+    /// <param name="operation">The <see cref="OpenApiOperation"/> object.</param>
+    /// <param name="name">The name of the parameter to retrieve.</param>
+    /// <returns>The <see cref="IOpenApiParameter"/> object with the specified name.</returns>
+    public static IOpenApiParameter? Parameter(this OpenApiOperation operation, string name)
+        => operation.Parameters?.GetByName(name);
+
+    /// <summary>
+    /// Gets the <see cref="IOpenApiResponse"/> by status code from the specified list of status codes.
+    /// </summary>
+    /// <param name="responses">The object that contains the list of <see cref="OpenApiResponse"/> objects.</param>
+    /// <param name="statusCode">The status code of the response to retrieve.</param>
+    /// <returns>The <see cref="IOpenApiResponse"/> object with the specified status code.</returns>
+    public static IOpenApiResponse GetByStatusCode(this OpenApiResponses responses, int statusCode)
+        => responses.SingleOrDefault(r => r.Key == statusCode.ToString()).Value;
+
+    /// <summary>
+    /// Gets by status code the <see cref="IOpenApiResponse"/> that is available in the <see cref="OpenApiOperation"/> responses list.
+    /// </summary>
+    /// <param name="operation">The <see cref="OpenApiOperation"/> object.</param>
+    /// <param name="statusCode">The status code of the response to retrieve.</param>
+    /// <returns>The <see cref="IOpenApiResponse"/> object with the specified status code.</returns>
+    public static IOpenApiResponse? Response(this OpenApiOperation operation, int statusCode)
+        => operation.Responses?.GetByStatusCode(statusCode);
+}
+
+#endif

--- a/src/MinimalHelpers.Routing/MinimalHelpers.Routing.csproj
+++ b/src/MinimalHelpers.Routing/MinimalHelpers.Routing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -18,7 +18,7 @@
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/marcominerva/MinimalHelpers.git</RepositoryUrl>
         <RepositoryBranch>master</RepositoryBranch>
-        <PackageReadmeFile>README.md</PackageReadmeFile>        
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/MinimalHelpers.Validation.Abstractions/MinimalHelpers.Validation.Abstractions.csproj
+++ b/src/MinimalHelpers.Validation.Abstractions/MinimalHelpers.Validation.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/MinimalHelpers.Validation/MinimalHelpers.Validation.csproj
+++ b/src/MinimalHelpers.Validation/MinimalHelpers.Validation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/MinimalHelpers.Validation/RouteHandlerBuilderExtensions.cs
+++ b/src/MinimalHelpers.Validation/RouteHandlerBuilderExtensions.cs
@@ -31,6 +31,9 @@ public static class RouteHandlerBuilderExtensions
     /// </example>
     /// </remarks>
     /// <seealso cref="ValidatorFilter{TModel}"/>
+#if NET10_0_OR_GREATER
+    [Obsolete("This method is obsolete starting from .NET 10. Consider using built-in validation features of .NET 10 and later.")]
+#endif
     public static RouteHandlerBuilder WithValidation<TModel>(this RouteHandlerBuilder builder) where TModel : class
     {
         builder.AddEndpointFilter<ValidatorFilter<TModel>>()


### PR DESCRIPTION
Updated project to target .NET 10.0 and replaced Data Annotations with FluentValidation for validation tasks. Updated C# version references to C# 14 in documentation. Removed `MinimalHelpers.Validation` library and its examples from the README. Introduced a new `PersonValidator` class for FluentValidation rules.

Refactored `Person` class to a record with nullable properties. Upgraded package references and added conditional compilation for OpenAPI extensions to ensure compatibility across .NET 8/9 and .NET 10+. Marked `WithValidation<TModel>` as obsolete for .NET 10+ with a recommendation to use built-in validation features.

Performed minor formatting adjustments and removed outdated examples from the documentation.

Closes #92 