### PR TITLE
Update .NET version in workflows to 10.x

### DIFF
--- a/.github/workflows/publish_fluentvalidation.yml
+++ b/.github/workflows/publish_fluentvalidation.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/MinimalHelpers.FluentValidation 
   PROJECT_FILE: MinimalHelpers.FluentValidation.csproj
   TAG_NAME: fluentvalidation

--- a/.github/workflows/publish_openapi.yml
+++ b/.github/workflows/publish_openapi.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/MinimalHelpers.OpenApi 
   PROJECT_FILE: MinimalHelpers.OpenApi.csproj
   TAG_NAME: openapi

--- a/.github/workflows/publish_routing.yml
+++ b/.github/workflows/publish_routing.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/MinimalHelpers.Routing 
   PROJECT_FILE: MinimalHelpers.Routing.csproj
   TAG_NAME: routing

--- a/.github/workflows/publish_routing_analyzers.yml
+++ b/.github/workflows/publish_routing_analyzers.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/MinimalHelpers.Routing.Analyzers 
   PROJECT_FILE: MinimalHelpers.Routing.Analyzers.csproj
   TAG_NAME: routing-analyzers

--- a/.github/workflows/publish_validation.yml
+++ b/.github/workflows/publish_validation.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '9.x'
+  NET_VERSION: '10.x'
   PROJECT_NAME: src/MinimalHelpers.Validation 
   PROJECT_FILE: MinimalHelpers.Validation.csproj
   TAG_NAME: validation


### PR DESCRIPTION
Updated the `NET_VERSION` environment variable in multiple GitHub Actions workflow files from `9.x` to `10.x` to align with the latest .NET version. This change affects the following projects:

- `MinimalHelpers.FluentValidation`
- `MinimalHelpers.OpenApi`
- `MinimalHelpers.Routing`
- `MinimalHelpers.Routing.Analyzers`
- `MinimalHelpers.Validation`

These updates ensure workflows leverage new features and improvements in .NET 10.x for building, testing, and publishing.