### PR TITLE
Update docs and bump OpenApi, SwaggerUI, TinyHelpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@
 - Return `Task` or `ValueTask` from asynchronous methods.
 - Use `CancellationToken` parameters to support cancellation.
 - Avoid async void methods except for event handlers.
-- Call `ConfigureAwait(false)` on awaited calls to avoid deadlocks.
+- Use `ConfigureAwait(false)` only in library code that may be consumed by apps with a `SynchronizationContext` (e.g., classic ASP.NET, WPF, WinForms); it is generally unnecessary in ASP.NET Core.
 
 ### Error Handling
 
@@ -82,8 +82,3 @@
 - Copy existing style in nearby files for test method names and capitalization.
 - When running tests, if possible use filters and check test run counts, or look at test logs, to ensure they actually ran.
 - Do not finish work with any tests commented out or disabled that were not previously commented out or disabled.
-
-## Azure
-- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
-- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/samples/MinimalSample/MinimalSample.csproj
+++ b/samples/MinimalSample/MinimalSample.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.2" />
-		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.17" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.5" />
+		<PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
+++ b/src/MinimalHelpers.OpenApi/MinimalHelpers.OpenApi.csproj
@@ -30,15 +30,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.24" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.25" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.13" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.14" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Clarified ConfigureAwait usage in copilot-instructions.md and removed Azure-specific rules. Updated package references in MinimalSample.csproj and MinimalHelpers.OpenApi.csproj to latest versions for Microsoft.AspNetCore.OpenApi, Swashbuckle.AspNetCore.SwaggerUI, and TinyHelpers.AspNetCore.